### PR TITLE
Fixed architecture detection

### DIFF
--- a/lib/adb/Device.py
+++ b/lib/adb/Device.py
@@ -161,10 +161,8 @@ class Device:
         output = pid.communicate()[0].decode().strip()
         getprop_archs = ["armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
         if output in getprop_archs:
-            if output in ["armeabi", "armeabi-v7a"]:
+            if output in ["armeabi", "armeabi-v7a","arm64-v8a"]:
                 arch = "arm"
-            elif output == "arm64-v8a":
-                arch = "arm64"
             else:
                 arch = output
 


### PR DESCRIPTION
There was bug when arch was arm-64 and no arm64 lib but a device having arm64 arch can run armv7 libs